### PR TITLE
Enable sign-up and login flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import LandingPage from './components/LandingPage';
 import SignUpPage from './components/SignUpPage';
 import FeedPage from './components/FeedPage';
 import UserProfileDashboard from './components/UserProfileDashboard';
+import LoginPage from './components/LoginPage';
 import DarkThemeWrapper from './components/DarkThemeWrapper';
 import './index.css';
 
@@ -13,6 +14,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/signup" element={<SignUpPage />} />
+          <Route path="/login" element={<LoginPage />} />
           <Route path="/feed" element={<FeedPage />} />
           <Route path="/profile" element={<UserProfileDashboard />} />
         </Routes>

--- a/client/src/components/LandingPage.jsx
+++ b/client/src/components/LandingPage.jsx
@@ -1,17 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+
 export default function LandingPage() {
+  const navigate = useNavigate();
+
   return (
     <div className="min-h-screen bg-[#FAFAFA] flex flex-col items-center p-6 text-[#2D2D2D]">
       <header className="w-full flex justify-between items-center max-w-6xl py-4">
         <h1 className="text-2xl font-bold text-[#E63946]">PopDish Zurich</h1>
         <div className="space-x-4">
-          <button className="px-4 py-2 bg-white text-[#E63946] border border-[#E63946] rounded-xl font-medium">Log In</button>
-          <button className="px-4 py-2 bg-[#E63946] text-white rounded-xl font-medium">Sign Up</button>
+          <button
+            onClick={() => navigate('/login')}
+            className="px-4 py-2 bg-white text-[#E63946] border border-[#E63946] rounded-xl font-medium"
+          >
+            Log In
+          </button>
+          <button
+            onClick={() => navigate('/signup')}
+            className="px-4 py-2 bg-[#E63946] text-white rounded-xl font-medium"
+          >
+            Sign Up
+          </button>
         </div>
       </header>
       <main className="text-center mt-24 max-w-xl">
         <h2 className="text-4xl font-semibold mb-4">Discover Zurich’s Best Pop-Up Food Spots</h2>
         <p className="text-lg text-gray-600 mb-8">Explore limited-time food experiences near you. Sign up to get personalized updates and access to exclusive pop-ups.</p>
-        <button className="px-6 py-3 bg-[#E63946] text-white text-lg rounded-xl font-semibold">Get Started</button>
+        <button
+          onClick={() => navigate('/signup')}
+          className="px-6 py-3 bg-[#E63946] text-white text-lg rounded-xl font-semibold"
+        >
+          Get Started
+        </button>
       </main>
     </div>
   );

--- a/client/src/components/LoginPage.jsx
+++ b/client/src/components/LoginPage.jsx
@@ -1,42 +1,34 @@
 import { useState } from 'react';
 
-export default function SignUpPage() {
-  const [username, setUsername] = useState('');
+export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [postalCode, setPostalCode] = useState('');
 
   async function handleSubmit(e) {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:3001/api/signup', {
+      const res = await fetch('http://localhost:3001/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, email, password, postalCode }),
+        body: JSON.stringify({ email, password }),
       });
       const data = await res.json();
       if (!res.ok) {
-        alert(data.message || 'Sign up failed');
+        alert(data.message || 'Login failed');
         return;
       }
-      alert('Signed up successfully!');
+      localStorage.setItem('token', data.token);
+      alert('Logged in!');
     } catch (err) {
       console.error(err);
-      alert('Error signing up');
+      alert('Error logging in');
     }
   }
 
   return (
     <div className="min-h-screen bg-[#FAFAFA] flex items-center justify-center p-6 text-[#2D2D2D]">
       <form onSubmit={handleSubmit} className="bg-white p-8 rounded-2xl shadow-lg w-full max-w-md space-y-6">
-        <h2 className="text-2xl font-semibold">Create Your Account</h2>
-        <input
-          type="text"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          placeholder="Username"
-          className="w-full border p-3 rounded-xl"
-        />
+        <h2 className="text-2xl font-semibold">Log In</h2>
         <input
           type="email"
           value={email}
@@ -51,14 +43,7 @@ export default function SignUpPage() {
           placeholder="Password"
           className="w-full border p-3 rounded-xl"
         />
-        <input
-          type="text"
-          value={postalCode}
-          onChange={(e) => setPostalCode(e.target.value)}
-          placeholder="Postal Code"
-          className="w-full border p-3 rounded-xl"
-        />
-        <button className="w-full py-3 bg-[#E63946] text-white rounded-xl font-medium">Sign Up</button>
+        <button className="w-full py-3 bg-[#E63946] text-white rounded-xl font-medium">Log In</button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- make landing page buttons navigate with `useNavigate`
- add login page component
- wire up SignUpPage to call backend API
- register login route in `App.jsx`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684efe29e8ac83279dd7a218b07672c5